### PR TITLE
travis: Run travis for release-.* branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ deploy:
     cleanup: true
     on:
       all_branches: true
-      condition: $TRAVIS_BRANCH =~ ^(ocp-.*|master)$
+      condition: $TRAVIS_BRANCH =~ ^(release-.*|master)$


### PR DESCRIPTION
It's been discussed and decided that the branch structure used is going
to be:
- master / main*: the current development;
- release-x.y: matching the OCP version we're targetting;

Only bug fixes should go to release-x.y, and those should be branched
from master / main* at some point, whenever we want to freeze the
current status.

*: Depending on what GitHub will end up adopting. :-)

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>